### PR TITLE
Addded changing nuke label color to red every 0.5 secs when available

### DIFF
--- a/hud.gd
+++ b/hud.gd
@@ -1,6 +1,9 @@
 extends CanvasLayer
 
 signal start_game
+const RED 	= Color(0xFF,0,0,0xFF)
+const WHITE = Color(0xFF,0xFF,0xFF,0xFF)
+static var color_index = 0
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -40,5 +43,18 @@ func _on_message_timer_timeout() -> void:
 func set_nuke_notif(nukeAvailable):
 	if(nukeAvailable):
 		$NukeNotif.show()
+		$NukePulseTimer.start()
 	else:
 		$NukeNotif.hide()
+		$NukePulseTimer.stop()
+
+func _on_nuke_pulse_timer_timeout() -> void:
+	var nuke_label_array = [WHITE, RED]
+	
+	#Change color of label
+	$NukeNotif.add_theme_color_override("font_color", nuke_label_array[color_index])
+	#Alternate color for next cycle
+	if(color_index == 1):
+		color_index = 0
+	else:
+		color_index = 1

--- a/hud.tscn
+++ b/hud.tscn
@@ -73,5 +73,9 @@ theme_override_fonts/font = ExtResource("1_lghhm")
 theme_override_font_sizes/font_size = 40
 text = "NUKE"
 
+[node name="NukePulseTimer" type="Timer" parent="."]
+wait_time = 0.5
+
 [connection signal="pressed" from="StartButton" to="." method="_on_start_button_pressed"]
 [connection signal="timeout" from="MessageTimer" to="." method="_on_message_timer_timeout"]
+[connection signal="timeout" from="NukePulseTimer" to="." method="_on_nuke_pulse_timer_timeout"]


### PR DESCRIPTION
# Type of PR:
- [x] 🎁 New feature
- [ ] 🚀 Code Improvement
- [ ] 🐛 Bug fix
- [ ] 🕵️‍♂️ Other (Build task, Workflow, Documentation, etc...)

# What does this PR do?:

- Adds functionality to change the color of the Nuke label from White to Red every 0.5 Seconds when the Nuke is available

# Known bugs:

- Nuke is still shown and changes color after game over and if nuke was available, this carries over to new game giving the ability for player to use nuke just starting the game