### PR TITLE
fixes bug in which Explosion sound volume wasn't controlled by master…

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -21,6 +21,8 @@ func _ready() -> void:
 	$DeathSound.volume_db = master_volume
 	$NukeBeam.volume_db = master_volume
 	$shoot.volume_db = master_volume
+	# Adding a negative offset to explosion, since it's too loud
+	$Explosion.volume_db = -9.0 + master_volume
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:
@@ -91,8 +93,14 @@ func _on_start_timer_timeout() -> void:
 	$MobTimer.start()
 	$ScoreTimer.start()
 
+# Function that handles the signal emitted when the player shoots
+# @param projectile: Variant, projectile to be instantiated
+# @param direction: Variant, direction of the player aiming
+# @param pos: Variant, position of the projectile
 func _on_player_pewpew(projectile: Variant, direction: Variant, pos: Variant) -> void:
 	var bullet = projectile.instantiate()
+	#Connect signal to handle enemy hit
+	bullet.projectile_enemy_hit.connect(_on_projectile_enemy_hit)
 	bullet.set_direction(direction)
 	bullet.position = pos
 	add_child(bullet)
@@ -105,6 +113,10 @@ func _on_player_boom(nuke: Variant, pos: Variant) -> void:
 		$HUD.set_nuke_notif(nukeAvailable)
 		var special_bomb = nuke.instantiate()
 		add_child(special_bomb)
+
+# Function that handles the signal emitted when a projectile hits an enemy
+func _on_projectile_enemy_hit():
+	$Explosion.play()
 
 # Called when changing aim type in the options menu by signal emitted
 # from options_menu.gd

--- a/main.tscn
+++ b/main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=13 format=4 uid="uid://ekty5hme78np"]
+[gd_scene load_steps=14 format=4 uid="uid://ekty5hme78np"]
 
 [ext_resource type="Script" path="res://main.gd" id="1_3c2qw"]
 [ext_resource type="PackedScene" uid="uid://dl456nch27lpc" path="res://player.tscn" id="1_q0je5"]
@@ -9,6 +9,7 @@
 [ext_resource type="AudioStream" uid="uid://ctd44dxkpx7tn" path="res://art/gameover.wav" id="6_h5chq"]
 [ext_resource type="AudioStream" uid="uid://bfhxfcxwkoep8" path="res://art/NukeBeam.wav" id="7_ufye1"]
 [ext_resource type="AudioStream" uid="uid://1ps6wf7eiovf" path="res://art/Pew Sound Effect.wav" id="9_8ootx"]
+[ext_resource type="AudioStream" uid="uid://cdtyr3rdeucfg" path="res://art/Explosion meme - Sound Effect.wav" id="10_efg4l"]
 
 [sub_resource type="Curve2D" id="Curve2D_6iyqv"]
 _data = {
@@ -75,6 +76,11 @@ stream = ExtResource("7_ufye1")
 [node name="shoot" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("9_8ootx")
 volume_db = -6.559
+max_polyphony = 10
+
+[node name="Explosion" type="AudioStreamPlayer2D" parent="."]
+stream = ExtResource("10_efg4l")
+volume_db = -21.55
 max_polyphony = 10
 
 [connection signal="boom" from="Player" to="." method="_on_player_boom"]

--- a/options_menu.gd
+++ b/options_menu.gd
@@ -2,7 +2,9 @@ extends Control
 
 # Signal emitted when the aim type is changed
 signal aim_type_changed(control_type)
-static var volume_db:float = 0.0
+# Master volume for game
+# -28 dB is equal to 65% volume
+static var volume_db:float = -28.0
 # Aim type (True = Mouse Aim / False = Keyboard Aim)
 static var aim_type:bool = false
 
@@ -30,6 +32,8 @@ func _on_volume_slider_value_changed(value: float) -> void:
 	$"../../DeathSound".volume_db = volume_db
 	$"../../NukeBeam".volume_db = volume_db
 	$"../../shoot".volume_db = volume_db
+	# Adding a negative offset to explosion, since it's too loud
+	$"../../Explosion".volume_db = -9.0 + volume_db
 
 func get_master_volume() -> float:
 	return volume_db

--- a/options_menu.tscn
+++ b/options_menu.tscn
@@ -50,6 +50,7 @@ offset_bottom = 36.565
 scale = Vector2(2, 2)
 
 [node name="AimTypeLabel" type="Label" parent="MarginContainer/VBoxContainer/Controls"]
+layout_mode = 0
 offset_left = 546.0
 offset_top = 12.565
 offset_right = 842.0

--- a/projectile.gd
+++ b/projectile.gd
@@ -1,5 +1,6 @@
 extends Area2D
 signal enemy_hit
+signal projectile_enemy_hit
 
 @export var SPEED = 400
 @export var SPAWN_TIME = 3
@@ -7,7 +8,6 @@ signal enemy_hit
 var direction : Vector2
 
 func _ready():
-	$CollisionShape2D.disabled = false
 	await get_tree().create_timer(SPAWN_TIME).timeout
 	position = global_position
 
@@ -21,18 +21,12 @@ func _on_body_entered(body: Node2D) -> void:
 	if body.is_in_group("mobs"):
 		#Delete instance of the mob we just hit
 		body.queue_free()
+		#Emit signal to be handled by main.gd
+		projectile_enemy_hit.emit()
 		#Emit signal that we just hit a mob
 		enemy_hit.emit()
 
 #Executes when enemy_hit is signaled
 func _on_enemy_hit() -> void:
-	#Play explosion sound when hitting an enemy
-	$Explosion.play()
-	#Disable collision so we only destroy one enemy with one projectile
-	$CollisionShape2D.set_deferred("disabled", true)
-	#Hide projectile as soon as it hits an enemy
-	hide()
-	#Wait for explosion sound to finish
-	await $Explosion.finished == true
 	#Delete projectile instance
 	queue_free()

--- a/projectile.tscn
+++ b/projectile.tscn
@@ -1,8 +1,7 @@
-[gd_scene load_steps=5 format=3 uid="uid://d1o02ict7qld1"]
+[gd_scene load_steps=4 format=3 uid="uid://d1o02ict7qld1"]
 
 [ext_resource type="Texture2D" uid="uid://d0h5rgv023tfx" path="res://art/Projectile.png" id="1_vfvuy"]
 [ext_resource type="Script" path="res://projectile.gd" id="1_xw02t"]
-[ext_resource type="AudioStream" uid="uid://cdtyr3rdeucfg" path="res://art/Explosion meme - Sound Effect.wav" id="3_7jv27"]
 
 [sub_resource type="CircleShape2D" id="CircleShape2D_8480h"]
 radius = 18.0278
@@ -17,11 +16,6 @@ texture = ExtResource("1_vfvuy")
 [node name="CollisionShape2D" type="CollisionShape2D" parent="."]
 position = Vector2(-1, -1)
 shape = SubResource("CircleShape2D_8480h")
-
-[node name="Explosion" type="AudioStreamPlayer2D" parent="."]
-stream = ExtResource("3_7jv27")
-volume_db = -21.55
-max_polyphony = 10
 
 [connection signal="body_entered" from="." to="." method="_on_body_entered"]
 [connection signal="enemy_hit" from="." to="." method="_on_enemy_hit"]


### PR DESCRIPTION
… volume slider from options menu

<!--Do not delete any of the options; type N/A if there is no corresponding information available-->
# What type of PR is this?
<!--Select at least one that is applicable-->
- [ ] 🎁 New feature
- [ ] 🚀 Code Improvement
- [x] 🐛 Bug fix
- [ ] 🕵️‍♂️ Other (Build task, Workflow, Documentation, etc...)

# What does this PR do?
<!-- Please provide a brief explanation of the changes made in this PR. -->

1. Fixes bug in which Explosion sound volume wasn't controlled by master volume slider in controls menu.
2. Adds a -9 dB offset to Explosion sound to compensate for the original wav file being too loud
3. Removes logic from projectile.gd in which we were delaying the destruction of the projectile instance to wait for Explosion sound to finish playing
4. Moves Explosion sound player node to main alongside the other sounds of the game

# Why was this PR created?
<!-- Please provide the motivation behind these changes. -->
Explosion sound was too loud and the options menu was unable to reduce its volume.

# Checklist items
<!-- The developer checklist item should be validated by the reviewer.  -->
- [ ] Testing and validation details attached
-  [Test Results](url)
- [ ] Design documentation attached (if applicable) 
- [x] Used meaningful commit messages
- [ ] Followed naming conventions and coding style compliance (if applicable)
- [x] Descriptive code comments added in Doxygen format (if applicable)
- [ ] Unit test cases added(if applicable)
- [ ] Verified memory usage stats (if applicable)

# Known Bugs
<!-- Please provide a brief explanation of known bugs noticed during the development of this change  -->
N/A

# Other related info
<!-- Use this to provide any additional related info  -->
N/A