### PR TITLE
Fixes bug in which player was able to shoot while in the settings menu

### DIFF
--- a/hud.gd
+++ b/hud.gd
@@ -1,6 +1,10 @@
 extends CanvasLayer
 
 signal start_game
+# Signal used to notify if the game is paused
+# @param state: bool, true if game is paused, false if game is resumed
+signal game_paused(state:bool)
+
 const RED 	= Color(0xFF,0,0,0xFF)
 const WHITE = Color(0xFF,0xFF,0xFF,0xFF)
 static var color_index = 0
@@ -82,9 +86,13 @@ func pauseMenu():
 	if !paused:
 		$OptionsMenu.show()
 		Engine.time_scale = 0
+		#Notify to main that the game is paused
+		emit_signal("game_paused", true)
 	else:
 		$OptionsMenu.hide()
 		Engine.time_scale = 1
+		#Notify to main that the game is resumed
+		emit_signal("game_paused", false)
 	
 	paused = !paused
 

--- a/main.gd
+++ b/main.gd
@@ -114,3 +114,10 @@ func _on_options_menu_aim_type_changed(control_type: Variant) -> void:
 	aim_type = control_type
 	# Setting aim type to player
 	$Player.set_aim_type(aim_type)
+
+# Called when the game is paused or resumed by signal emitted from hud.gd
+# @param state: bool, true if game is paused, false if game is resumed
+func _on_hud_game_paused(state: bool) -> void:
+	#Send the pause signal to the player to disable
+	#therefore we send the complement of the pause state
+	$Player.set_player_can_shoot(!state)

--- a/main.tscn
+++ b/main.tscn
@@ -83,5 +83,6 @@ max_polyphony = 10
 [connection signal="timeout" from="MobTimer" to="." method="_on_mob_timer_timeout"]
 [connection signal="timeout" from="ScoreTimer" to="." method="_on_score_timer_timeout"]
 [connection signal="timeout" from="StartTimer" to="." method="_on_start_timer_timeout"]
+[connection signal="game_paused" from="HUD" to="." method="_on_hud_game_paused"]
 [connection signal="start_game" from="HUD" to="." method="new_game"]
 [connection signal="aim_type_changed" from="HUD/OptionsMenu" to="." method="_on_options_menu_aim_type_changed"]

--- a/options_menu.tscn
+++ b/options_menu.tscn
@@ -50,6 +50,7 @@ offset_bottom = 36.565
 scale = Vector2(2, 2)
 
 [node name="AimTypeLabel" type="Label" parent="MarginContainer/VBoxContainer/Controls"]
+layout_mode = 0
 offset_left = 546.0
 offset_top = 12.565
 offset_right = 842.0

--- a/player.gd
+++ b/player.gd
@@ -106,3 +106,8 @@ func nuke():
 # @param control_aim: bool
 func set_aim_type(control_aim: bool):
 	aim_type = control_aim
+
+# Function that sets the player's ability to shoot
+# @param shootEnabled: bool, true if player can shoot, false if player can't shoot
+func set_player_can_shoot(shootEnabled: bool):
+	canShoot = shootEnabled


### PR DESCRIPTION
<!--Do not delete any of the options; type N/A if there is no corresponding information available-->
# What type of PR is this?
<!--Select at least one that is applicable-->
- [ ] 🎁 New feature
- [ ] 🚀 Code Improvement
- [x] 🐛 Bug fix
- [ ] 🕵️‍♂️ Other (Build task, Workflow, Documentation, etc...)

# What does this PR do?
<!-- Please provide a brief explanation of the changes made in this PR. -->
Fixes bug in which player was able to shoot while in the settings menu

1. Adds a signal coming from HUD that signals main that the game is paused
2. Adds a function that sets the abilty for the player to be able to shoot or not
3. Main processes the Pause signal by setting the player ability to shoot or not based on the Pause state from HUD

# Why was this PR created?
<!-- Please provide the motivation behind these changes. -->
To fix [Issue #10: Shooting is not disabled in the menu](https://github.com/S4tchel93/GodotGameTest/issues/10)

# Checklist items
<!-- The developer checklist item should be validated by the reviewer.  -->
- [ ] Testing and validation details attached
-  [Test Results](url)
- [ ] Design documentation attached (if applicable) 
- [x] Used meaningful commit messages
- [ ] Followed naming conventions and coding style compliance (if applicable)
- [x] Descriptive code comments added in Doxygen format (if applicable)
- [ ] Unit test cases added(if applicable)
- [ ] Verified memory usage stats (if applicable)

# Known Bugs
<!-- Please provide a brief explanation of known bugs noticed during the development of this change  -->
N/A

# Other related info
<!-- Use this to provide any additional related info  -->
N/A