### PR TITLE
Adds the feature to increment score on mob hit

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -75,8 +75,6 @@ func _on_mob_timer_timeout() -> void:
 	add_child(mob)
 
 func _on_score_timer_timeout() -> void:
-	score += 1
-	$HUD.update_score(score)
 	
 	#Set difficulty (mob speed) up every INCREASE_DIFFICULTY_SCORE score points
 	if(score % INCREASE_DIFFICULTY_SCORE == 0 && score > 0):
@@ -112,11 +110,23 @@ func _on_player_boom(nuke: Variant, pos: Variant) -> void:
 		nukeAvailable = false
 		$HUD.set_nuke_notif(nukeAvailable)
 		var special_bomb = nuke.instantiate()
+		#Connect signal to handle enemy hit when nuke is used
+		special_bomb.nuke_hit_mob.connect(_on_nuke_hit_mob)
 		add_child(special_bomb)
 
 # Function that handles the signal emitted when a projectile hits an enemy
 func _on_projectile_enemy_hit():
+	increment_score()
 	$Explosion.play()
+
+# Function that handles the signal emitted when a nuke hits an enemy
+func _on_nuke_hit_mob():
+	increment_score()
+
+# Function that increments the score and updates the HUD
+func increment_score():
+	score += 1
+	$HUD.update_score(score)
 
 # Called when changing aim type in the options menu by signal emitted
 # from options_menu.gd

--- a/nuke.gd
+++ b/nuke.gd
@@ -1,5 +1,8 @@
 extends Area2D
 
+#Signal to notify that a mob was hit by the nuke
+signal nuke_hit_mob()
+
 func _ready():
 	#instantiate a nuke
 	$CollisionShape2D.disabled = false
@@ -15,6 +18,8 @@ func _physics_process(delta: float) -> void:
 
 func _on_body_entered(body: Node2D) -> void:
 	if body.is_in_group("mobs"):
+		#Emit signal to notify to main.gd that a mob was hit by the nuke
+		emit_signal("nuke_hit_mob")
 		#Delete instance of the mob we just hit
 		body.queue_free()
 


### PR DESCRIPTION
<!--Do not delete any of the options; type N/A if there is no corresponding information available-->
# What type of PR is this?
<!--Select at least one that is applicable-->
- [x] 🎁 New feature
- [x] 🚀 Code Improvement
- [ ] 🐛 Bug fix
- [ ] 🕵️‍♂️ Other (Build task, Workflow, Documentation, etc...)

# What does this PR do?
<!-- Please provide a brief explanation of the changes made in this PR. -->
Adds the feature to increment score on mob hit instead of 1 Second timeout

1. Adds signal on nuke.gd to notify that the nuke collision just hit a mob
2. Implements a function in main.gd that connects to the newly added nuke signal
3. On every enemy hit (by projectile or nuke), the score is incremented by "1"

# Why was this PR created?
<!-- Please provide the motivation behind these changes. -->
To make the game score dependent on user abilty to hit enemies instead of dodging

# Checklist items
<!-- The developer checklist item should be validated by the reviewer.  -->
- [ ] Testing and validation details attached
-  [Test Results](url)
- [ ] Design documentation attached (if applicable) 
- [x] Used meaningful commit messages
- [ ] Followed naming conventions and coding style compliance (if applicable)
- [x] Descriptive code comments added in Doxygen format (if applicable)
- [ ] Unit test cases added(if applicable)
- [ ] Verified memory usage stats (if applicable)

# Known Bugs
<!-- Please provide a brief explanation of known bugs noticed during the development of this change  -->
N/A

# Other related info
<!-- Use this to provide any additional related info  -->
N/A