### PR TITLE
Fixes Score Update race condition

### DIFF
--- a/main.gd
+++ b/main.gd
@@ -29,7 +29,6 @@ func _process(delta: float) -> void:
 	pass
 
 func game_over() -> void:
-	$ScoreTimer.stop()
 	$MobTimer.stop()
 	$HUD.show_game_over()
 	$Music.stop()
@@ -74,22 +73,8 @@ func _on_mob_timer_timeout() -> void:
 	# Spawn the mob by adding it to the Main scene.
 	add_child(mob)
 
-func _on_score_timer_timeout() -> void:
-	
-	#Set difficulty (mob speed) up every INCREASE_DIFFICULTY_SCORE score points
-	if(score % INCREASE_DIFFICULTY_SCORE == 0 && score > 0):
-		difficulty += 100.0
-		print("current difficulty: " + str(difficulty/100.0))
-		
-	#Set Nuke Available after player gets sums up a NUKE_AVAILABLE_SC0RE score
-	if(score % NUKE_AVAILABLE_SC0RE == 0 && score > 0 && nukeAvailable == false):
-		nukeAvailable = true
-		$HUD.set_nuke_notif(nukeAvailable)
-		print("Nuke Available: " + str(nukeAvailable))
-
 func _on_start_timer_timeout() -> void:
 	$MobTimer.start()
-	$ScoreTimer.start()
 
 # Function that handles the signal emitted when the player shoots
 # @param projectile: Variant, projectile to be instantiated
@@ -123,9 +108,12 @@ func _on_projectile_enemy_hit():
 func _on_nuke_hit_mob():
 	increment_score()
 
-# Function that increments the score and updates the HUD
+# Function that increments the score, updates the HUD
+# and checks for gameplay changes based on score
 func increment_score():
 	score += 1
+	check_difficulty()
+	check_nuke_available()
 	$HUD.update_score(score)
 
 # Called when changing aim type in the options menu by signal emitted
@@ -143,3 +131,20 @@ func _on_hud_game_paused(state: bool) -> void:
 	#Send the pause signal to the player to disable
 	#therefore we send the complement of the pause state
 	$Player.set_player_can_shoot(!state)
+
+# Function that checks if the player has reached a certain score
+# to increase the difficulty of the game
+func check_difficulty():
+	#Set difficulty (mob speed) up every INCREASE_DIFFICULTY_SCORE score points
+	if(score % INCREASE_DIFFICULTY_SCORE == 0 && score > 0):
+		difficulty += 100.0
+		print("current difficulty: " + str(difficulty/100.0))
+
+# Function that checks if the player has reached a certain score
+# to make the nuke available
+func check_nuke_available():
+	#Set Nuke Available after player gets sums up a NUKE_AVAILABLE_SC0RE score
+	if(score % NUKE_AVAILABLE_SC0RE == 0 && score > 0 && nukeAvailable == false):
+		nukeAvailable = true
+		$HUD.set_nuke_notif(nukeAvailable)
+		print("Nuke Available: " + str(nukeAvailable))

--- a/main.tscn
+++ b/main.tscn
@@ -42,8 +42,6 @@ expand_mode = 1
 [node name="MobTimer" type="Timer" parent="."]
 wait_time = 0.5
 
-[node name="ScoreTimer" type="Timer" parent="."]
-
 [node name="StartTimer" type="Timer" parent="."]
 wait_time = 2.0
 one_shot = true
@@ -87,7 +85,6 @@ max_polyphony = 10
 [connection signal="hit" from="Player" to="." method="game_over"]
 [connection signal="pewpew" from="Player" to="." method="_on_player_pewpew"]
 [connection signal="timeout" from="MobTimer" to="." method="_on_mob_timer_timeout"]
-[connection signal="timeout" from="ScoreTimer" to="." method="_on_score_timer_timeout"]
 [connection signal="timeout" from="StartTimer" to="." method="_on_start_timer_timeout"]
 [connection signal="game_paused" from="HUD" to="." method="_on_hud_game_paused"]
 [connection signal="start_game" from="HUD" to="." method="new_game"]


### PR DESCRIPTION
<!--Do not delete any of the options; type N/A if there is no corresponding information available-->
# What type of PR is this?
<!--Select at least one that is applicable-->
- [ ] 🎁 New feature
- [ ] 🚀 Code Improvement
- [x] 🐛 Bug fix
- [ ] 🕵️‍♂️ Other (Build task, Workflow, Documentation, etc...)

# What does this PR do?
<!-- Please provide a brief explanation of the changes made in this PR. -->
This PR fixes an issue created by the previous PR. There was a race condition in which the score could go beyond the Nuke Available value before the 1 second timer expired to check if the nuke was needed to be set as available, therefore there were missed points in which the nuke should've been available due to the score but it wasn't available.

**Fix:** Move the Nuke Available and Difficulty logic out of the Score Timer Expiring function and move it to the function where the score is incremented. In this way, the checks for Nuke and Difficulty are done instantly after the Score has been increased instead of waiting for a timeout.

# Why was this PR created?
<!-- Please provide the motivation behind these changes. -->
There was a race condition between the Score Update function and the Logic for Nuke Available and Difficulty Setting

# Checklist items
<!-- The developer checklist item should be validated by the reviewer.  -->
- [ ] Testing and validation details attached
-  [Test Results](url)
- [ ] Design documentation attached (if applicable) 
- [x] Used meaningful commit messages
- [ ] Followed naming conventions and coding style compliance (if applicable)
- [x] Descriptive code comments added in Doxygen format (if applicable)
- [ ] Unit test cases added(if applicable)
- [ ] Verified memory usage stats (if applicable)

# Known Bugs
<!-- Please provide a brief explanation of known bugs noticed during the development of this change  -->
N/A

# Other related info
<!-- Use this to provide any additional related info  -->
N/A